### PR TITLE
Handle 7bit control codes

### DIFF
--- a/handterm.cpp
+++ b/handterm.cpp
@@ -384,9 +384,20 @@ void FastFast_UpdateTerminalW(TermOutputBuffer& tb, const wchar_t* str, SIZE_T c
         wchar_t c = *str;
         if (vt_processing_enabled)
         {
-            action = vt_process_char_w(&tb.vt_state, str, count == 1);
-            str++;
-            count--;
+            wchar_t cnext = *(str + 1);
+            // ESC + 7bit control characters.
+            if (c == L'\x1b' && cnext >= L'\x40' && cnext <= L'\x5f') {
+                // Convert it to C1 control codes.
+                c = cnext + L'\x40';
+                action = vt_process_char_w(&tb.vt_state, &c, count == 1);
+                str += 2;
+                count -= 2;
+            }
+            else {
+                action = vt_process_char_w(&tb.vt_state, str, count == 1);
+                str++;
+                count--;
+            }
 
             switch (action) {
             case CsiDispatch: {


### PR DESCRIPTION
This is my very naïve attempt add support for 7bit control codes.

The corresponding PR in Windows Terminal is https://github.com/microsoft/terminal/pull/7340, which converts all C1 control codes to C0. This PR does the opposite, but practically both way work the same, I think.

7bit (C0) control codes are presumably more often used than 8bit (C1) control codes.